### PR TITLE
feat: add solo endorsements 

### DIFF
--- a/app/Modules/Bookings/BookingsService.php
+++ b/app/Modules/Bookings/BookingsService.php
@@ -84,6 +84,30 @@ class BookingsService
         });
     }
 
+    /**
+     * Validate if the user is allowed to book on the position on the premise of them having a solo endorsement.
+     * Should be used in conjunction with a rating check.
+     *
+     * @param  User  $user
+     * @param  Position  $position
+     * @return bool
+     */
+    public function validateSoloEndorsementEligibility(User $user, Position $position): bool
+    {
+        $soloEndorsements = $position->load('soloEndorsements')->soloEndorsements()->where(function ($query) {
+            return $query->active();
+        })->get();
+
+        // exit if no active endorsements on position to save later queries.
+        if ($soloEndorsements->isEmpty()) {
+            return false;
+        }
+
+        $userAssignedSoloEndorsements = $soloEndorsements->where('user_id', '==', $user->id);
+
+        return ! $userAssignedSoloEndorsements->isEmpty();
+    }
+
     public function createBooking(array $bookingData): Booking
     {
         ['from' => $from, 'to' => $to] = $bookingData;
@@ -92,7 +116,9 @@ class BookingsService
         $bookingUser = $this->user::findOrFail($bookingData['user_id']);
 
         if (! $this->validateRatingRequirement($bookingUser, $position)) {
-            throw new RatingRequirementNotMetException();
+            if (! $this->validateSoloEndorsementEligibility($bookingUser, $position)) {
+                throw new RatingRequirementNotMetException();
+            }
         }
 
         if (! $this->validateSpecialEndorsementRequirement($bookingUser, $position)) {

--- a/app/Modules/Endorsement/Solo/GrantSoloEndorsementHandler.php
+++ b/app/Modules/Endorsement/Solo/GrantSoloEndorsementHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+
+namespace App\Modules\Endorsement\Solo;
+
+
+use App\Exceptions\OverlappingBookingException;
+use App\Modules\Position\Position;
+use App\User;
+use GraphQL\Type\Definition\ResolveInfo;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+
+class GrantSoloEndorsementHandler
+{
+    /**
+     * Return a value for the field.
+     *
+     * @param  null  $rootValue  Usually contains the result returned from the parent field. In this case, it is always `null`.
+     * @param  mixed[]  $args  The arguments that were passed into the field.
+     * @param  GraphQLContext  $context  Arbitrary data that is shared between all fields of a single query.
+     * @param  ResolveInfo  $resolveInfo  Information about the query itself, such as the execution state, the field name, path to the field from the root, and more.
+     * @throws OverlappingBookingException
+     */
+    public function __invoke($rootValue, array $args, GraphQLContext $context, ResolveInfo $resolveInfo)
+    {
+        /** @var SoloEndorsementService $service */
+        $service = app()->make(SoloEndorsementService::class);
+
+        $position = Position::find($args['position_id']);
+        $user = resolve(User::class)->findOrFail($args['user_id']);
+
+        return $service->grantSoloEndorsement($position, $user);
+    }
+}

--- a/app/Modules/Endorsement/Solo/GrantSoloEndorsementHandler.php
+++ b/app/Modules/Endorsement/Solo/GrantSoloEndorsementHandler.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace App\Modules\Endorsement\Solo;
-
 
 use App\Exceptions\OverlappingBookingException;
 use App\Modules\Position\Position;

--- a/app/Modules/Endorsement/Solo/SoloEndorsement.php
+++ b/app/Modules/Endorsement/Solo/SoloEndorsement.php
@@ -2,12 +2,18 @@
 
 namespace App\Modules\Endorsement\Solo;
 
+use App\Modules\Position\Position;
+use App\User;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use VATSIMUK\Auth\Remote\RemoteEloquent\HasCustomInstanceCreation;
 
 class SoloEndorsement extends Model
 {
+    use HasCustomInstanceCreation;
+
     protected $fillable = ['user_id', 'position_id', 'expiry_date'];
 
     protected $dates = ['expiry_date'];
@@ -15,5 +21,15 @@ class SoloEndorsement extends Model
     public function scopeActive(Builder $query): Builder
     {
         return $query->whereDate('expiry_date', '>', Carbon::now());
+    }
+
+    public function position(): BelongsTo
+    {
+        return $this->belongsTo(Position::class, 'position_id', 'id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(resolve(User::class), 'user_id');
     }
 }

--- a/app/Modules/Endorsement/Solo/SoloEndorsement.php
+++ b/app/Modules/Endorsement/Solo/SoloEndorsement.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Modules\Endorsement\Solo;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class SoloEndorsement extends Model
+{
+    protected $fillable = ['user_id', 'position_id', 'expiry_date'];
+
+    protected $dates = ['expiry_date'];
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->whereDate('expiry_date', '>', Carbon::now());
+    }
+}

--- a/app/Modules/Endorsement/Solo/SoloEndorsementAlreadyGrantedException.php
+++ b/app/Modules/Endorsement/Solo/SoloEndorsementAlreadyGrantedException.php
@@ -9,7 +9,7 @@ class SoloEndorsementAlreadyGrantedException extends Exception implements Render
 {
     protected $message = 'A solo endorsement is already assigned to that user on the given position';
 
-        /**
+    /**
      * Returns true when exception message is safe to be displayed to a client.
      *
      * @return bool

--- a/app/Modules/Endorsement/Solo/SoloEndorsementAlreadyGrantedException.php
+++ b/app/Modules/Endorsement/Solo/SoloEndorsementAlreadyGrantedException.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Modules\Endorsement\Solo;
+
+use Exception;
+use Nuwave\Lighthouse\Exceptions\RendersErrorsExtensions;
+
+class SoloEndorsementAlreadyGrantedException extends Exception implements RendersErrorsExtensions
+{
+    protected $message = 'A solo endorsement is already assigned to that user on the given position';
+
+        /**
+     * Returns true when exception message is safe to be displayed to a client.
+     *
+     * @return bool
+     *
+     * @api
+     */
+    public function isClientSafe()
+    {
+        return true;
+    }
+
+    /**
+     * Returns string describing a category of the error.
+     *
+     * Value "graphql" is reserved for errors produced by query parsing or validation, do not use it.
+     *
+     * @return string
+     *
+     * @api
+     */
+    public function getCategory()
+    {
+        return 'validation';
+    }
+
+    /**
+     * Return the content that is put in the "extensions" part
+     * of the returned error.
+     *
+     * @return array
+     */
+    public function extensionsContent(): array
+    {
+        return [
+            'code' => 422,
+        ];
+    }
+}

--- a/app/Modules/Endorsement/Solo/SoloEndorsementService.php
+++ b/app/Modules/Endorsement/Solo/SoloEndorsementService.php
@@ -18,7 +18,7 @@ class SoloEndorsementService
         return SoloEndorsement::create([
             'position_id' => $position->id,
             'user_id' => $user->id,
-            'expiry_date' => Carbon::now()->addDays(30)
+            'expiry_date' => Carbon::now()->addDays(30),
         ]);
     }
 
@@ -26,7 +26,7 @@ class SoloEndorsementService
     {
         $queryResult = SoloEndorsement::active()->where([
             'position_id' => $position->id,
-            'user_id' => $user->id
+            'user_id' => $user->id,
         ])->get();
 
         return ! $queryResult->isEmpty();

--- a/app/Modules/Endorsement/Solo/SoloEndorsementService.php
+++ b/app/Modules/Endorsement/Solo/SoloEndorsementService.php
@@ -8,6 +8,8 @@ use Carbon\Carbon;
 
 class SoloEndorsementService
 {
+    private const DEFAULT_DURATION_IN_DAYS = 30;
+
     public function grantSoloEndorsement(Position $position, User $user): SoloEndorsement
     {
         throw_if(
@@ -18,7 +20,7 @@ class SoloEndorsementService
         return SoloEndorsement::create([
             'position_id' => $position->id,
             'user_id' => $user->id,
-            'expiry_date' => Carbon::now()->addDays(30)
+            'expiry_date' => Carbon::now()->addDays(self::DEFAULT_DURATION_IN_DAYS)
         ]);
     }
 

--- a/app/Modules/Endorsement/Solo/SoloEndorsementService.php
+++ b/app/Modules/Endorsement/Solo/SoloEndorsementService.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Modules\Endorsement\Solo;
+
+use App\Modules\Position\Position;
+use App\User;
+use Carbon\Carbon;
+
+class SoloEndorsementService
+{
+    public function grantSoloEndorsement(Position $position, User $user): SoloEndorsement
+    {
+        throw_if(
+            $this->checkForExistingActiveSoloEndorsements($position, $user),
+            SoloEndorsementAlreadyGrantedException::class
+        );
+
+        return SoloEndorsement::create([
+            'position_id' => $position->id,
+            'user_id' => $user->id,
+            'expiry_date' => Carbon::now()->addDays(30)
+        ]);
+    }
+
+    public function checkForExistingActiveSoloEndorsements(Position $position, User $user): bool
+    {
+        $queryResult = SoloEndorsement::active()->where([
+            'position_id' => $position->id,
+            'user_id' => $user->id
+        ])->get();
+
+        return ! $queryResult->isEmpty();
+    }
+}

--- a/app/Modules/Endorsement/Solo/SoloEndorsementService.php
+++ b/app/Modules/Endorsement/Solo/SoloEndorsementService.php
@@ -20,7 +20,7 @@ class SoloEndorsementService
         return SoloEndorsement::create([
             'position_id' => $position->id,
             'user_id' => $user->id,
-            'expiry_date' => Carbon::now()->addDays(self::DEFAULT_DURATION_IN_DAYS)
+            'expiry_date' => Carbon::now()->addDays(self::DEFAULT_DURATION_IN_DAYS),
         ]);
     }
 

--- a/app/Modules/Position/Position.php
+++ b/app/Modules/Position/Position.php
@@ -48,11 +48,7 @@ class Position extends Model
 
     public function soloEndorsements(): HasMany
     {
-        return $this->hasMany(
-            SoloEndorsement::class,
-            'position_id',
-            'id'
-        );
+        return $this->hasMany(SoloEndorsement::class, 'position_id', 'id');
     }
 
     public function getTypeAttribute(): string

--- a/app/Modules/Position/Position.php
+++ b/app/Modules/Position/Position.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Position;
 
 use App\Modules\Bookings\Booking;
+use App\Modules\Endorsement\Solo\SoloEndorsement;
 use App\Modules\Endorsement\Special\SpecialEndorsement;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -42,6 +43,15 @@ class Position extends Model
             'special_endorsement_positions',
             'position_id',
             'endorsement_id'
+        );
+    }
+
+    public function soloEndorsements(): HasMany
+    {
+        return $this->hasMany(
+            SoloEndorsement::class,
+            'position_id',
+            'id'
         );
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,9 +3,9 @@
 namespace App\Providers;
 
 use App\Modules\Bookings\BookingsService;
+use App\Modules\Endorsement\Solo\SoloEndorsementService;
 use App\Modules\Position\TrainingPositionService;
 use Illuminate\Support\ServiceProvider;
-use App\Modules\Endorsement\Solo\SoloEndorsementService;
 
 class AppServiceProvider extends ServiceProvider
 {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Modules\Bookings\BookingsService;
 use App\Modules\Position\TrainingPositionService;
 use Illuminate\Support\ServiceProvider;
+use App\Modules\Endorsement\Solo\SoloEndorsementService;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -17,6 +18,7 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->singleton(BookingsService::class);
         $this->app->singleton(TrainingPositionService::class);
+        $this->app->singleton(SoloEndorsementService::class);
     }
 
     /**

--- a/database/factories/SoloEndorsementFactory.php
+++ b/database/factories/SoloEndorsementFactory.php
@@ -2,11 +2,13 @@
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
-use App\Modules\Endorsement\SoloEndorsement;
+use App\Modules\Endorsement\Solo\SoloEndorsement;
 use Faker\Generator as Faker;
 
 $factory->define(SoloEndorsement::class, function (Faker $faker) {
     return [
-        //
+        'position_id' => factory(\App\Modules\Endorsement\Solo\SoloEndorsement::class),
+        'user_id' => factory(\App\User::class),
+        'expiry_date' => \Carbon\Carbon::now()->addDays(30)
     ];
 });

--- a/database/factories/SoloEndorsementFactory.php
+++ b/database/factories/SoloEndorsementFactory.php
@@ -9,6 +9,6 @@ $factory->define(SoloEndorsement::class, function (Faker $faker) {
     return [
         'position_id' => factory(\App\Modules\Endorsement\Solo\SoloEndorsement::class),
         'user_id' => factory(\App\User::class),
-        'expiry_date' => \Carbon\Carbon::now()->addDays(30)
+        'expiry_date' => \Carbon\Carbon::now()->addDays(30),
     ];
 });

--- a/database/factories/SoloEndorsementFactory.php
+++ b/database/factories/SoloEndorsementFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Modules\Endorsement\SoloEndorsement;
+use Faker\Generator as Faker;
+
+$factory->define(SoloEndorsement::class, function (Faker $faker) {
+    return [
+        //
+    ];
+});

--- a/database/migrations/2020_02_07_073710_create_solo_endorsements_table.php
+++ b/database/migrations/2020_02_07_073710_create_solo_endorsements_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSoloEndorsementsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('solo_endorsements', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('position_id');
+            $table->unsignedBigInteger('user_id');
+            $table->timestamp('expiry_date');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('solo_endorsements');
+    }
+}

--- a/graphql/endorsement.graphql
+++ b/graphql/endorsement.graphql
@@ -2,6 +2,7 @@ extend type Query {
     specialEndorsements: [SpecialEndorsement!]! @all
     specialEndorsement(id: ID @eq): SpecialEndorsement @find
     specialEndorsementsForUser(user_id: ID): [SpecialEndorsement]! @field(resolver: "App\\Modules\\Endorsement\\Special\\Mutations\\SpecialEndorsementsForUser")
+    activeSoloEndorsements: [SoloEndorsement!]! @all(model: "App\\Modules\\Endorsement\\Solo\\SoloEndorsement", scopes: ["active"])
 }
 
 input SpecialEndorsementInput {
@@ -12,6 +13,11 @@ input SpecialEndorsementRequestInput {
     user_id: ID!
     endorsement_id: Int! @rules(apply: ["exists:special_endorsements,id"])
     requested_by: Int!
+}
+
+input SoloEndorsementRequestInput {
+    user_id: ID!
+    position_id: Int! @rules(apply: ["exists:positions,id"])
 }
 
 extend type Mutation {
@@ -28,13 +34,16 @@ extend type Mutation {
 
     requestSpecialEndorsement(input: SpecialEndorsementRequestInput! @spread): EndorsementRequest!
     @field(resolver: "App\\Modules\\Endorsement\\Special\\Mutations\\RequestSpecialEndorsementHandler")
+
+    grantSoloEndorsement(input: SoloEndorsementRequestInput! @spread): SoloEndorsement!
+    @field(resolver: "App\\Modules\\Endorsement\\Solo\\GrantSoloEndorsementHandler")
 }
 interface Endorsement {
     id: ID!
     name: String!
     users: [User!]
 }
-type SpecialEndorsement implements Endorsement{
+type SpecialEndorsement implements Endorsement {
     id: ID!
     name: String!
     deleted_at: DateTime
@@ -42,6 +51,12 @@ type SpecialEndorsement implements Endorsement{
     updated_at: DateTime!
     pivot: Assignment!
     users: [User!]
+}
+
+type SoloEndorsement {
+    id: ID!
+    position: Position!
+    user: User!
 }
 
 type EndorsementRequest {

--- a/tests/Feature/Booking/BookingCreateTest.php
+++ b/tests/Feature/Booking/BookingCreateTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Booking;
 
 use App\Modules\Bookings\Booking;
+use App\Modules\Endorsement\Solo\SoloEndorsement;
 use App\Modules\Endorsement\Special\Assignment;
 use App\Modules\Endorsement\Special\SpecialEndorsement;
 use App\Modules\Position\Position;
@@ -97,14 +98,14 @@ class BookingCreateTest extends TestCase
                 id
             }
           }")->assertJsonStructure([
-            'errors' => [
-                [
-                    'message',
-                    'extensions',
-                    'locations',
+                'errors' => [
+                    [
+                        'message',
+                        'extensions',
+                        'locations',
+                    ],
                 ],
-            ],
-        ]
+            ]
         );
 
         $unknownPositionId = 2;
@@ -122,14 +123,14 @@ class BookingCreateTest extends TestCase
                 id
             }
           }")->assertJsonStructure([
-            'errors' => [
-                [
-                    'message',
-                    'extensions',
-                    'locations',
+                'errors' => [
+                    [
+                        'message',
+                        'extensions',
+                        'locations',
+                    ],
                 ],
-            ],
-        ]
+            ]
         );
 
         // "From" and "To" the same
@@ -146,14 +147,14 @@ class BookingCreateTest extends TestCase
                 id
             }
           }')->assertJsonStructure([
-            'errors' => [
-                [
-                    'message',
-                    'extensions',
-                    'locations',
+                'errors' => [
+                    [
+                        'message',
+                        'extensions',
+                        'locations',
+                    ],
                 ],
-            ],
-        ]
+            ]
         );
 
         // "From" after "To"
@@ -163,14 +164,14 @@ class BookingCreateTest extends TestCase
                 id
             }
           }")->assertJsonStructure([
-            'errors' => [
-                [
-                    'message',
-                    'extensions',
-                    'locations',
+                'errors' => [
+                    [
+                        'message',
+                        'extensions',
+                        'locations',
+                    ],
                 ],
-            ],
-        ]
+            ]
         );
     }
 
@@ -360,6 +361,68 @@ class BookingCreateTest extends TestCase
             }
         }")->assertJsonPath('errors.0.message',
             'You do not have the required Special Endorsement to book this position.');
+    }
+
+    /** @test */
+    public function testAllowsBookingWhenRatingRequirementNotMetButSoloEndorsementIsActive()
+    {
+        // mocked user has an S2 rating
+        $this->mockedUser();
+
+        // lets set the position to require an S3
+        $this->position->callsign = 'EGGD_APP';
+        $this->position->save();
+
+        // create the endorsement on our position...
+        factory(SoloEndorsement::class)->create([
+            'position_id' => $this->position->id, 'user_id' => $this->mockUserId
+        ]);
+
+        $this->graphQL("
+          mutation {
+            createBooking(
+                input: {
+                    position_id: {$this->position->id},
+                    from:\"2019-01-10 14:00:00\",
+                    to:\"2019-01-10 15:00:00\"
+                }
+            )
+            {
+                id
+            }
+        }")->assertJsonStructure(['data' => ['createBooking' => ['id']]]);
+    }
+
+    /** @test */
+    public function testDoesntAllowBookingWhenSoloEndorsementOnPositionHasExpired()
+    {
+        // mocked user has an S2 rating
+        $this->mockedUser();
+
+        // lets set the position to require an S3
+        $this->position->callsign = 'EGGD_APP';
+        $this->position->save();
+
+        // create the endorsement on our position which has expired ...
+        factory(SoloEndorsement::class)->create([
+            'position_id' => $this->position->id,
+            'user_id' => $this->mockUserId,
+            'expiry_date' => Carbon::now()->subDay()
+        ]);
+
+        $this->graphQL("
+          mutation {
+            createBooking(
+                input: {
+                    position_id: {$this->position->id},
+                    from:\"2019-01-10 14:00:00\",
+                    to:\"2019-01-10 15:00:00\"
+                }
+            )
+            {
+                id
+            }
+        }")->assertJsonPath('errors.0.message', 'Your rating is not high enough to book that position.');
     }
 
     /** @test */

--- a/tests/Feature/Booking/BookingCreateTest.php
+++ b/tests/Feature/Booking/BookingCreateTest.php
@@ -98,14 +98,14 @@ class BookingCreateTest extends TestCase
                 id
             }
           }")->assertJsonStructure([
-                'errors' => [
-                    [
-                        'message',
-                        'extensions',
-                        'locations',
-                    ],
+            'errors' => [
+                [
+                    'message',
+                    'extensions',
+                    'locations',
                 ],
-            ]
+            ],
+        ]
         );
 
         $unknownPositionId = 2;
@@ -123,14 +123,14 @@ class BookingCreateTest extends TestCase
                 id
             }
           }")->assertJsonStructure([
-                'errors' => [
-                    [
-                        'message',
-                        'extensions',
-                        'locations',
-                    ],
+            'errors' => [
+                [
+                    'message',
+                    'extensions',
+                    'locations',
                 ],
-            ]
+            ],
+        ]
         );
 
         // "From" and "To" the same
@@ -147,14 +147,14 @@ class BookingCreateTest extends TestCase
                 id
             }
           }')->assertJsonStructure([
-                'errors' => [
-                    [
-                        'message',
-                        'extensions',
-                        'locations',
-                    ],
+            'errors' => [
+                [
+                    'message',
+                    'extensions',
+                    'locations',
                 ],
-            ]
+            ],
+        ]
         );
 
         // "From" after "To"
@@ -164,14 +164,14 @@ class BookingCreateTest extends TestCase
                 id
             }
           }")->assertJsonStructure([
-                'errors' => [
-                    [
-                        'message',
-                        'extensions',
-                        'locations',
-                    ],
+            'errors' => [
+                [
+                    'message',
+                    'extensions',
+                    'locations',
                 ],
-            ]
+            ],
+        ]
         );
     }
 
@@ -375,7 +375,7 @@ class BookingCreateTest extends TestCase
 
         // create the endorsement on our position...
         factory(SoloEndorsement::class)->create([
-            'position_id' => $this->position->id, 'user_id' => $this->mockUserId
+            'position_id' => $this->position->id, 'user_id' => $this->mockUserId,
         ]);
 
         $this->graphQL("
@@ -407,7 +407,7 @@ class BookingCreateTest extends TestCase
         factory(SoloEndorsement::class)->create([
             'position_id' => $this->position->id,
             'user_id' => $this->mockUserId,
-            'expiry_date' => Carbon::now()->subDay()
+            'expiry_date' => Carbon::now()->subDay(),
         ]);
 
         $this->graphQL("

--- a/tests/Feature/Endorsement/SoloEndorsementQueryTest.php
+++ b/tests/Feature/Endorsement/SoloEndorsementQueryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature\Endorsement;
+
+use App\Modules\Endorsement\Solo\SoloEndorsement;
+use App\Modules\Position\Position;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\TestResponse;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Tests\TestCase;
+
+class SoloEndorsementQueryTest extends TestCase
+{
+    use RefreshDatabase, MakesGraphQLRequests;
+
+    private $position;
+    private $mockUserId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->position = factory(Position::class)->create();
+
+        $this->mockUserId = 1112220;
+    }
+
+    /** @test */
+    public function testSoloEndorsementCanBeGrantedViaMutation()
+    {
+        $this->mockRemoteUserCall($this->mockUserId);
+
+        $this->grantSoloEndorsementQuery()
+            ->assertJsonPath('data.grantSoloEndorsement.user.id', $this->mockUserId)
+            ->assertJsonPath('data.grantSoloEndorsement.position.callsign', $this->position->callsign);
+    }
+
+    /** @test */
+    public function testSoloEndorsementIsntCreatedIfAlreadyActive()
+    {
+        factory(SoloEndorsement::class)->create(['position_id' => $this->position->id, 'user_id' => $this->mockUserId]);
+
+        $this->mockRemoteUserCall($this->mockUserId);
+
+        $this->grantSoloEndorsementQuery()
+            ->assertJsonPath('errors.0.message',
+                'A solo endorsement is already assigned to that user on the given position');
+    }
+
+    private function grantSoloEndorsementQuery(): TestResponse
+    {
+        return $this->graphQL("
+        mutation {
+            grantSoloEndorsement (
+                input: {
+                    position_id: {$this->position->id}
+                    user_id: {$this->mockUserId}
+                }
+            ) {
+                id
+                user {
+                    id
+                }
+                position {
+                    callsign
+                }
+            }
+        }");
+    }
+
+    private function mockRemoteUserCall(int $userId): void
+    {
+        $userMockReturn = User::initModelWithData([
+            'id' => $userId,
+            'name_first' => 'Callum',
+        ]);
+
+        $this->mock(User::class, function ($mock) use ($userId, $userMockReturn) {
+            $mock->shouldReceive('findOrFail')
+                ->andReturn($userMockReturn);
+
+            $mock->shouldReceive('find')
+                ->andReturn($userMockReturn);
+        })->makePartial();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,6 +13,6 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
-        Carbon::setTestNow();
+        Carbon::setTestNow(Carbon::now());
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,6 +13,6 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow();
     }
 }

--- a/tests/Unit/Booking/BookingsServiceTest.php
+++ b/tests/Unit/Booking/BookingsServiceTest.php
@@ -335,7 +335,7 @@ class BookingsServiceTest extends TestCase
         SoloEndorsement::create([
             'position_id' => $this->position->id,
             'user_id' => $this->mockUserId,
-            'expiry_date' => Carbon::now()->addDays(2)
+            'expiry_date' => Carbon::now()->addDays(2),
         ]);
 
         $this->assertTrue($this->service->validateSoloEndorsementEligibility($this->mockUserModel, $this->position));
@@ -353,7 +353,7 @@ class BookingsServiceTest extends TestCase
         SoloEndorsement::create([
             'position_id' => $this->position->id,
             'user_id' => $this->mockUserId,
-            'expiry_date' => Carbon::now()->subDay()
+            'expiry_date' => Carbon::now()->subDay(),
         ]);
 
         $this->assertFalse($this->service->validateSoloEndorsementEligibility($this->mockUserModel, $this->position));

--- a/tests/Unit/Booking/BookingsServiceTest.php
+++ b/tests/Unit/Booking/BookingsServiceTest.php
@@ -6,6 +6,7 @@ use App\Exceptions\OverlappingBookingException;
 use App\Modules\Bookings\Booking;
 use App\Modules\Bookings\BookingsService;
 use App\Modules\Bookings\RatingRequirementNotMetException;
+use App\Modules\Endorsement\Solo\SoloEndorsement;
 use App\Modules\Endorsement\Special\Assignment;
 use App\Modules\Endorsement\Special\SpecialEndorsement;
 use App\Modules\Position\Position;
@@ -326,6 +327,36 @@ class BookingsServiceTest extends TestCase
             'from' => new Carbon('10th January 2019 13:00:00'),
             'to' => new Carbon('10th January 2019 14:00:00'),
         ]);
+    }
+
+    /** @test */
+    public function itShouldReturnTrueIfUserHasActiveSpecialEndorsementOnPosition()
+    {
+        SoloEndorsement::create([
+            'position_id' => $this->position->id,
+            'user_id' => $this->mockUserId,
+            'expiry_date' => Carbon::now()->addDays(2)
+        ]);
+
+        $this->assertTrue($this->service->validateSoloEndorsementEligibility($this->mockUserModel, $this->position));
+    }
+
+    /** @test */
+    public function itShouldReturnFalseIfUserHasNeverHadSoloEndorsementOnPosition()
+    {
+        $this->assertFalse($this->service->validateSoloEndorsementEligibility($this->mockUserModel, $this->position));
+    }
+
+    /** @test */
+    public function itShouldReturnFalseIfUserHasExpiredSoloEndorsementOnPosition()
+    {
+        SoloEndorsement::create([
+            'position_id' => $this->position->id,
+            'user_id' => $this->mockUserId,
+            'expiry_date' => Carbon::now()->subDay()
+        ]);
+
+        $this->assertFalse($this->service->validateSoloEndorsementEligibility($this->mockUserModel, $this->position));
     }
 
     private function grantEndorsementHelper($user_id, $endorsement_id)

--- a/tests/Unit/Endorsement/SoloEndorsementModelTest.php
+++ b/tests/Unit/Endorsement/SoloEndorsementModelTest.php
@@ -29,13 +29,13 @@ class SoloEndorsementModelTest extends TestCase
         $expiredEndorsement = SoloEndorsement::create([
             'position_id' => $this->position->id,
             'user_id' => $user->id,
-            'expiry_date' => Carbon::now()->subHours(1)
+            'expiry_date' => Carbon::now()->subHours(1),
         ]);
 
         $activeEndorsement = SoloEndorsement::create([
             'position_id' => $this->position->id,
             'user_id' => $user->id,
-            'expiry_date' => Carbon::now()->addHours(24)
+            'expiry_date' => Carbon::now()->addHours(24),
         ]);
 
         $collectionResult = SoloEndorsement::active()->get();

--- a/tests/Unit/Endorsement/SoloEndorsementModelTest.php
+++ b/tests/Unit/Endorsement/SoloEndorsementModelTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Unit\Endorsement;
+
+use App\Modules\Endorsement\Solo\SoloEndorsement;
+use App\Modules\Position\Position;
+use App\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SoloEndorsementModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private $position;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->position = factory(Position::class)->create();
+    }
+
+    /** @test */
+    public function itDeterminesActiveSoloEndorsementsByReturningOnlyThoseEndorsementsWhichHaveNotExpired()
+    {
+        $user = User::initModelWithData(['id' => 1234567]);
+        $expiredEndorsement = SoloEndorsement::create([
+            'position_id' => $this->position->id,
+            'user_id' => $user->id,
+            'expiry_date' => Carbon::now()->subHours(1)
+        ]);
+
+        $activeEndorsement = SoloEndorsement::create([
+            'position_id' => $this->position->id,
+            'user_id' => $user->id,
+            'expiry_date' => Carbon::now()->addHours(24)
+        ]);
+
+        $collectionResult = SoloEndorsement::active()->get();
+
+        $this->assertTrue($collectionResult->contains($activeEndorsement));
+        $this->assertFalse($collectionResult->contains($expiredEndorsement));
+    }
+}

--- a/tests/Unit/Endorsement/SoloEndorsementServiceTest.php
+++ b/tests/Unit/Endorsement/SoloEndorsementServiceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Modules\Endorsement\Solo\SoloEndorsement;
+use App\Modules\Endorsement\Solo\SoloEndorsementAlreadyGrantedException;
+use App\Modules\Endorsement\Solo\SoloEndorsementService;
+use App\Modules\Position\Position;
+use App\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SoloEndorsementServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private $service;
+    private $position;
+    private $mockUserId = 1234567;
+    private $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = $this->app->make(SoloEndorsementService::class);
+
+        $this->position = factory(Position::class)->create();
+
+        $this->user = User::initModelWithData(['id' => $this->mockUserId]);
+    }
+
+    /** @test */
+    public function itShouldCreateSoloEndorsementAgainstPositionAndUser()
+    {
+        $this->service->grantSoloEndorsement($this->position, $this->user);
+
+        $this->assertDatabaseHas('solo_endorsements', [
+            'position_id' => $this->position->id,
+            'user_id' => $this->user->id,
+            'expiry_date' => Carbon::now()->addDays(30)
+        ]);
+    }
+
+    /** @test */
+    public function itShouldNotGrantSoloEndorsementIfAlreadyAssignedToUser()
+    {
+        $this->expectException(SoloEndorsementAlreadyGrantedException::class);
+
+        SoloEndorsement::create([
+            'position_id' => $this->position->id,
+            'user_id' => $this->user->id,
+            'expiry_date' => Carbon::now()->addDays(30)
+        ]);
+
+        $this->service->grantSoloEndorsement($this->position, $this->user);
+    }
+
+    /** @test */
+    public function itCorrectlyDeterminesIfSoloEndorsementIsCurrentlyActive()
+    {
+        SoloEndorsement::create([
+            'position_id' => $this->position->id,
+            'user_id' => $this->user->id,
+            'expiry_date' => Carbon::now()->addDays(30)
+        ]);
+
+        $result = $this->service->checkForExistingActiveSoloEndorsements($this->position, $this->user);
+
+        $this->assertTrue($result);
+    }
+
+    /** @test */
+    public function itCorrectlyDeterminesIfSoloEndorsementHasExpired()
+    {
+        $user = User::initModelWithData(['id' => $this->mockUserId]);
+        SoloEndorsement::create([
+            'position_id' => $this->position->id,
+            'user_id' => $user->id,
+            'expiry_date' => Carbon::now()->subDays(1)
+        ]);
+
+        $result = $this->service->checkForExistingActiveSoloEndorsements($this->position, $this->user);
+
+        $this->assertFalse($result);
+    }
+}

--- a/tests/Unit/Endorsement/SoloEndorsementServiceTest.php
+++ b/tests/Unit/Endorsement/SoloEndorsementServiceTest.php
@@ -39,7 +39,7 @@ class SoloEndorsementServiceTest extends TestCase
         $this->assertDatabaseHas('solo_endorsements', [
             'position_id' => $this->position->id,
             'user_id' => $this->user->id,
-            'expiry_date' => Carbon::now()->addDays(30)
+            'expiry_date' => Carbon::now()->addDays(30),
         ]);
     }
 
@@ -51,7 +51,7 @@ class SoloEndorsementServiceTest extends TestCase
         SoloEndorsement::create([
             'position_id' => $this->position->id,
             'user_id' => $this->user->id,
-            'expiry_date' => Carbon::now()->addDays(30)
+            'expiry_date' => Carbon::now()->addDays(30),
         ]);
 
         $this->service->grantSoloEndorsement($this->position, $this->user);
@@ -63,7 +63,7 @@ class SoloEndorsementServiceTest extends TestCase
         SoloEndorsement::create([
             'position_id' => $this->position->id,
             'user_id' => $this->user->id,
-            'expiry_date' => Carbon::now()->addDays(30)
+            'expiry_date' => Carbon::now()->addDays(30),
         ]);
 
         $result = $this->service->checkForExistingActiveSoloEndorsements($this->position, $this->user);
@@ -78,7 +78,7 @@ class SoloEndorsementServiceTest extends TestCase
         SoloEndorsement::create([
             'position_id' => $this->position->id,
             'user_id' => $user->id,
-            'expiry_date' => Carbon::now()->subDays(1)
+            'expiry_date' => Carbon::now()->subDays(1),
         ]);
 
         $result = $this->service->checkForExistingActiveSoloEndorsements($this->position, $this->user);

--- a/tests/Unit/Position/PositionUnitTest.php
+++ b/tests/Unit/Position/PositionUnitTest.php
@@ -53,10 +53,9 @@ class PositionUnitTest extends TestCase
     {
         factory(SoloEndorsement::class, 3)->create([
             'position_id' => $this->position->id,
-            'user_id' => 134566
+            'user_id' => 134566,
         ]);
 
         $this->assertCount(3, $this->position->soloEndorsements);
     }
-
 }

--- a/tests/Unit/Position/PositionUnitTest.php
+++ b/tests/Unit/Position/PositionUnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Position;
 
+use App\Modules\Endorsement\Solo\SoloEndorsement;
 use App\Modules\Endorsement\Special\SpecialEndorsement;
 use App\Modules\Position\Position;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -46,4 +47,16 @@ class PositionUnitTest extends TestCase
         $this->assertEquals(1, $this->position->specialEndorsements()->count());
         $this->assertEquals($endorsements->last()->name, $this->position->specialEndorsements()->first()->name);
     }
+
+    /** @test */
+    public function itCanBeRelatedToSoloEndorsements()
+    {
+        factory(SoloEndorsement::class, 3)->create([
+            'position_id' => $this->position->id,
+            'user_id' => 134566
+        ]);
+
+        $this->assertCount(3, $this->position->soloEndorsements);
+    }
+
 }


### PR DESCRIPTION
Closes #40.

**Summary of Changes**

- Adds SoloEndorsement model w/ query scope for active endorsements
- Adds service to handle SoloEndorsement granting
- Adds query to retrieve all active solo endorsements as required by .NET
- Adds check to bookings to allow a user to book a position which they don't hold the rating for, but have an active solo endorsement