### PR TITLE
Fixes codecov for pull requests

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -23,7 +23,7 @@ jobs:
         DB_DATABASE: database/database.sqlite
       run: vendor/bin/phpunit --coverage-clover=coverage.xml
     - name: Upload Code Coverage Report
-      uses: codecov/codecov-action@v1.0.5
+      uses: codecov/codecov-action@v1.0.7
       with:
         file: ./coverage.xml
         fail_ci_if_error: true

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -25,6 +25,5 @@ jobs:
     - name: Upload Code Coverage Report
       uses: codecov/codecov-action@v1.0.5
       with:
-        token: ${{secrets.CODECOV_TOKEN}}
         file: ./coverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
As of a month or two ago, some sort of API has been added which allows for tokenless uploads to Codecov for open-source repositories and their subsequent forks. See here: https://github.com/codecov/codecov-action/issues/29#issuecomment-594958141