### PR TITLE
fix: availability table migration not running in MySQL strict mode

### DIFF
--- a/database/migrations/2020_02_03_204857_create_availability_table.php
+++ b/database/migrations/2020_02_03_204857_create_availability_table.php
@@ -19,7 +19,7 @@ class CreateAvailabilityTable extends Migration
             $table->timestamp('from')->nullable()
                 ->comment('Nullable to enforce compatibility with MYSQL strict mode.');
             $table->timestamp('to')->nullable()
-                ->nullable('Nullable to enforce compatibility with MYSQL strict mode.');
+                ->comment('Nullable to enforce compatibility with MYSQL strict mode.');
             $table->timestamps();
         });
     }

--- a/database/migrations/2020_02_03_204857_create_availability_table.php
+++ b/database/migrations/2020_02_03_204857_create_availability_table.php
@@ -16,8 +16,10 @@ class CreateAvailabilityTable extends Migration
         Schema::create('availability', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedInteger('user_id');
-            $table->timestamp('from');
-            $table->timestamp('to');
+            $table->timestamp('from')->nullable()
+                ->comment('Nullable to enforce compatibility with MYSQL strict mode.');
+            $table->timestamp('to')->nullable()
+                ->nullable('Nullable to enforce compatibility with MYSQL strict mode.');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
- Adds nullable to the 'from' & 'to' columns on the availability table. This fixes the issue by allowing null timestamps (whereas the default MySQL stance is not to do so)﻿
